### PR TITLE
チャットスペースのフロント画面の実装

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,0 +1,29 @@
+.Chat
+  .RightHeader
+    .RightHeader__group
+      .RightHeader__groupName
+        グループ名
+      %ul.RightHeader__memberList
+        メンバー：
+        %li.RightHeader__member
+          ユーザー名
+    = link_to '#',class: "RightHeader__editButton" do
+      Edit
+  .MessageField
+    .MessageBox
+      .MessageInfo
+        .MessageInfo__userName
+          ユーザー名
+        .MessageInfo__date
+          2020/7/22 9:58
+      .Message
+        %p.Message__content
+          おはよう
+  .Footer
+    %form.Form
+      .Form__contents
+        %input.Form__inputContent{type: 'text', placeholder: 'type a message'}
+        %label.Form__inputImage
+          = icon('far', 'image', class: 'Form__icon')
+          %input.Hidden{type: 'file'}
+      %input.Form__submit{type: 'submit', value: 'Send'}


### PR DESCRIPTION
# What
ChatSpaceのチャット画面を実装する。ユーザー名、アイコン、グループ一覧、グループ概要、メッセージ一覧、投稿フォームを表示させた。

# Why
記事投稿表示は、本アプリケーションの根幹機能であるため。