### PR TITLE
ChatSpaceのメッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,5 @@ gem 'devise'
 gem 'pry-rails'
 gem 'carrierwave'
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -263,6 +267,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -56,7 +56,11 @@ $(function(){
       let html = buildHTML(data);
       $('.MessageField').append(html); 
       $('.MessageField').animate({ scrollTop: $('.MessageField')[0].scrollHeight});     
+      $('.Form__submit').prop('disabled', false);
       $('form')[0].reset();
     })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,62 @@
 $(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html =
+        `<div class="MessageBox">
+          <div class="MessageInfo">
+            <div class="MessageInfo__userName">
+              ${message.user_name}
+            </div>
+            <div class="MessageInfo__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="Message">
+            <p class="Message__content">
+              ${message.content}
+            </p>
+            <img class="Message__image" src="${message.image}">
+          </div>
+        </div>`
+      return html;
+    } else {
+      let html =
+      `<div class="MessageBox">
+        <div class="MessageInfo">
+          <div class="MessageInfo__userName">
+            ${message.user_name}
+          </div>
+          <div class="MessageInfo__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="Message">
+          <p class="Message__content">
+            ${message.content}
+          </p>
+        </div>
+      </div>`
+      return html;
+    };
+  }
+
   $('.Form').on('submit', function(e){
-    e.preventDefault()
-    console.log("hoge")
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.MessageField').append(html); 
+      $('.MessageField').animate({ scrollTop: $('.MessageField')[0].scrollHeight});     
+      $('form')[0].reset();
+    })
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,6 @@
+$(function(){
+  $('.Form').on('submit', function(e){
+    e.preventDefault()
+    console.log("hoge")
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,11 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
+    # if @message.save
+      # redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
+    = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
+    -# = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ module ChatSpace
     end
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
# What
JavaScriptとjQueryを使用するための準備
これから記述するjsファイルを作成して、jQueryが読み込めることを確認
フォームが送信されたら、イベントが発火するようにする
5 イベントが発火したときにAjaxを使用して、messages#createが動くようにする
6 messages#createでメッセージを保存し、
respond_toを使用してHTMLとJSONの場合で処理を分ける
7 jbuilderを使用して、作成したメッセージをJSON形式で返す
8 返ってきたJSONをdoneメソッドで受取り、HTMLを作成
9 作成したHTMLをメッセージ画面の一番下に追加
10 メッセージを送信したとき、メッセージ画面を最下部にスクロール
11 連続で送信ボタンを押せるようにする
12 非同期に失敗した場合の処理も準備
13 日時表示を日本時間に修正

# Why
現状でもメッセージの送信機能を実装してあるが、メッセージを送信するたびに送信画面にリダイレクトしているため、ビューが毎回再描画されてしまう。これまでに学んだ非同期通信を使って、メッセージの送信を非同期で行えるようにする必要があるから。